### PR TITLE
Bump to Quill Version 1.3.7

### DIFF
--- a/django_quill/templates/django_quill/media.html
+++ b/django_quill/templates/django_quill/media.html
@@ -5,8 +5,8 @@
 <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js"></script>
 
 <!-- Quill.js -->
-<link href="//cdn.quilljs.com/1.3.6/quill.snow.css" rel="stylesheet">
-<script src="//cdn.quilljs.com/1.3.6/quill.min.js"></script>
+<link href="//cdn.quilljs.com/1.3.7/quill.snow.css" rel="stylesheet">
+<script src="//cdn.quilljs.com/1.3.7/quill.min.js"></script>
 
 <!-- Custom -->
 <link rel="stylesheet" href="{% static 'django_quill/django_quill.css' %}">

--- a/docs/pages/using-as-form.md
+++ b/docs/pages/using-as-form.md
@@ -1,5 +1,28 @@
 # Using as Form
 
+Add the CSS and JS to the `<head>` of the template or base template. 
+
+There are two ways to add CSS and JS files to a template.
+
+  - If there is a **Form** with QuillField added, add `{{ form.media }}` to the `<head>` tag.  
+
+    ```django
+    <head>
+        {{ form.media }}
+    </head>
+    ```
+
+  - Or, import CSS and JS files directly using `{% include %}` template tags.
+
+    ```django
+    <head>
+        <!-- django-quill-editor Media -->
+        {% include 'django_quill/media.html' %}
+    </head>
+    ```
+
+    
+
 Add `QuillFormField` to the **Form class** you want to use.
 
 ```python
@@ -23,7 +46,6 @@ from .forms import QuillFieldForm
 def form_view(request):
     return render(request, 'form_view.html', {'form': QuillFieldForm()})
 ```
-
 
 
 In the template, use the received **Form instance** variable. (in the above case, **'form'**) 


### PR DESCRIPTION
Bump to Quill Version 1.3.7 - This version of Quill fixes Quill Vuln https://github.com/quilljs/quill/issues/2438

The current version of Quill (`1.3.6`) that `django-quill-editor` uses has an active vulnerability open. Bumping to Quill version `1.3.7` fixes the issue. 

Here is the change commit to fix the vuln in Quill https://github.com/quilljs/quill/pull/2439

The Vuln is described here: https://ossindex.sonatype.org/vuln/d96c07dd-81f9-41f6-b2bd-531143bcaeab