### PR TITLE
Image uploader support

### DIFF
--- a/django_quill/static/django_quill/django_quill.css
+++ b/django_quill/static/django_quill/django_quill.css
@@ -1,3 +1,7 @@
-div.form-row.field-content div.django-quill-widget-container {
+div.form-row.field-content, div.django-quill-widget-container {
     display: inline-block;
+}
+
+.ql-editor{
+    min-height:350px;
 }

--- a/django_quill/static/django_quill/django_quill.js
+++ b/django_quill/static/django_quill/django_quill.js
@@ -1,17 +1,66 @@
 class QuillWrapper {
-    constructor(targetDivId, targetInputId, quillOptions) {
-        this.targetDiv = document.getElementById(targetDivId);
-        if (!this.targetDiv) throw 'Target div(' + targetDivId + ') id was invalid';
+  constructor(targetDivId, targetInputId, uploadURL, quillOptions) {
+    this.targetDiv = document.getElementById(targetDivId);
+    if (!this.targetDiv) throw 'Target div(' + targetDivId + ') id was invalid';
 
-        this.targetInput = document.getElementById(targetInputId);
-        if (!this.targetInput) throw 'Target Input id was invalid';
+    this.targetInput = document.getElementById(targetInputId);
+    if (!this.targetInput) throw 'Target Input id was invalid';
 
-        this.quill = new Quill('#' + targetDivId, quillOptions);
-        this.quill.on('text-change', () => {
-            var delta = JSON.stringify(this.quill.getContents());
-            var html = this.targetDiv.getElementsByClassName('ql-editor')[0].innerHTML;
-            var data = {delta: delta, html: html};
-            this.targetInput.value = JSON.stringify(data);
-        });
+    if (quillOptions.useInlineStyleAttributes) {
+      // https://quilljs.com/guides/how-to-customize-quill/#class-vs-inline
+      Quill.register(Quill.import('attributors/style/align'), true);
     }
+
+    if (uploadURL) {
+      // https://www.npmjs.com/package/quill-image-uploader
+      Quill.register("modules/imageUploader", ImageUploader);
+
+      var imageUploaderModule = {
+        upload: file => {
+          return new Promise((resolve, reject) => {
+            const formData = new FormData();
+            formData.append("image", file);
+
+            fetch(
+                uploadURL, {
+                  method: "POST",
+                  body: formData,
+                  headers: {
+                    'X-CSRFToken': document.querySelector('[name=csrfmiddlewaretoken]').value
+                  },
+                }
+              )
+              .then(response => response.json())
+              .then(result => {
+                console.log(result);
+                resolve(result.image_url);
+              })
+              .catch(error => {
+                reject("Upload failed");
+                alert("Uploading  failed");
+                console.error("Error:", error);
+              });
+          });
+        }
+      }
+
+    }
+
+    this.quill = new Quill('#' + targetDivId, {
+      ...quillOptions,
+      modules: {
+        ...quillOptions.modules,
+        imageUploader: imageUploaderModule
+      }
+    });
+    this.quill.on('text-change', () => {
+      var delta = JSON.stringify(this.quill.getContents());
+      var html = this.targetDiv.getElementsByClassName('ql-editor')[0].innerHTML;
+      var data = {
+        delta: delta,
+        html: html
+      };
+      this.targetInput.value = JSON.stringify(data);
+    });
+  }
 }

--- a/django_quill/templates/django_quill/media.html
+++ b/django_quill/templates/django_quill/media.html
@@ -9,5 +9,8 @@
 <script src="//cdn.quilljs.com/1.3.6/quill.min.js"></script>
 
 <!-- Custom -->
+<link rel="stylesheet" href="https://unpkg.com/quill-image-uploader@1.2.2/dist/quill.imageUploader.min.css"/>
+<script src="https://unpkg.com/quill-image-uploader@1.2.2/dist/quill.imageUploader.min.js"></script>
+
 <link rel="stylesheet" href="{% static 'django_quill/django_quill.css' %}">
 <script src="{% static 'django_quill/django_quill.js' %}"></script>

--- a/django_quill/templates/django_quill/widget.html
+++ b/django_quill/templates/django_quill/widget.html
@@ -2,9 +2,13 @@
 <div class="vLargeTextField django-quill-widget-container">
     <div id="quill-{{ id }}" class="django-quill-widget" data-config="{{ config }}" data-type="django-quill"></div>
     <input id="quill-input-{{ id }}" name="{{ name }}" type="hidden">
+    {% url 'quill-editor-upload' as upload_url %}
+    {% if not upload_url %}
+      {% url '' as upload_url %}
+    {% endif %}
     <script>
         (function () {
-            var wrapper = new QuillWrapper('quill-{{ id }}', 'quill-input-{{ id }}', JSON.parse('{{ config|safe }}'));
+            var wrapper = new QuillWrapper('quill-{{ id }}', 'quill-input-{{ id }}', '{{upload_url}}', JSON.parse('{{ config|safe }}'));
             {% if quill and quill.delta %}
                 // try django_quill/quill.py/Quill instance
                 var contents = JSON.parse('{{ quill.delta|safe|escapejs }}');

--- a/django_quill/widgets.py
+++ b/django_quill/widgets.py
@@ -32,13 +32,15 @@ class QuillWidget(forms.Textarea):
     class Media:
         js = (
             'https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js',
-            'django_quill/django_quill.js',
             'https://cdn.quilljs.com/1.3.6/quill.min.js',
+            'https://unpkg.com/quill-image-uploader@1.2.2/dist/quill.imageUploader.min.js',
+            'django_quill/django_quill.js',
         )
         css = {
             'all': (
                 'https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/darcula.min.css',
                 'django_quill/django_quill.css',
+                'https://unpkg.com/quill-image-uploader@1.2.2/dist/quill.imageUploader.min.css',
                 'https://cdn.quilljs.com/1.3.6/quill.snow.css',
             )
         }


### PR DESCRIPTION
Adds image uploader support (using [quill-image-uploader](https://www.npmjs.com/package/quill-image-uploader)).

Related issue: https://github.com/LeeHanYeong/django-quill-editor/issues/32 

- TODO: Add documentation for new/changed features
  - Upload view should return `image_url` (add an example response)
  - name of the upload view should be `quill-editor-upload` (maybe add an example view)
  - `useInlineStyleAttributes` configuration