### PR TITLE
Fixed single quote error

### DIFF
--- a/django_quill/templates/django_quill/widget.html
+++ b/django_quill/templates/django_quill/widget.html
@@ -17,7 +17,7 @@
                 }
                 // When a parsing error occurs, the contents are regarded as HTML and the contents of the editor are filled.
                 catch (e) {
-                    wrapper.quill.clipboard.dangerouslyPasteHTML(0, '{{ value|safe }}')
+                    wrapper.quill.clipboard.dangerouslyPasteHTML(0, '{{ value|escape|safe }}')
                 }
             {% endif %}
         })();


### PR DESCRIPTION
Hi,

When the field content contains a single quote, I get the error: 
```
Uncaught SyntaxError: missing ) after argument list
```
This is due to the `value` widget template variable not being escaped and causing situations like:
```js
wrapper.quill.clipboard.dangerouslyPasteHTML(0, '{"delta":"{\"ops\":[{\"insert\":\"'\\n\"}]}","html":"<p>'</p>"}')
```
which is causing the error above. 

When this error occurs, the quilljs widget does not render at all.

Adding the `escape` filter to the  `dangerouslyPasteHTML` function argument seems to fix this bug.

Cheers.