### PR TITLE
fix convert_to_quill command - adding only

### DIFF
--- a/django_quill/management/commands/convert_to_quill.py
+++ b/django_quill/management/commands/convert_to_quill.py
@@ -20,7 +20,7 @@ class Command(BaseCommand):
         field_name = options["field_name"]
 
         model = apps.get_registered_model(app_label, model_name)
-        instances = model.objects.all()
+        instances = model.objects.all().only(field_name)
         for index, instance in enumerate(instances, start=1):
             print(
                 f"[{index}/{len(instances)}] {model_name} (pk: {instance.pk}) converting"

--- a/django_quill/management/commands/convert_to_quill.py
+++ b/django_quill/management/commands/convert_to_quill.py
@@ -20,7 +20,7 @@ class Command(BaseCommand):
         field_name = options["field_name"]
 
         model = apps.get_registered_model(app_label, model_name)
-        instances = model.objects.all().only(field_name)
+        instances = model.objects.only(field_name)
         for index, instance in enumerate(instances, start=1):
             print(
                 f"[{index}/{len(instances)}] {model_name} (pk: {instance.pk}) converting"

--- a/django_quill/widgets.py
+++ b/django_quill/widgets.py
@@ -30,8 +30,7 @@ json_encode = LazyEncoder().encode
 
 class QuillWidget(forms.Textarea):
     class Media:
-        # Do not include JS files here due to multiple definitions.
-        # js = MEDIA_JS
+        js = MEDIA_JS
         css = {"all": MEDIA_CSS}
 
     def __init__(self, config_name="default", *args, **kwargs):

--- a/django_quill/widgets.py
+++ b/django_quill/widgets.py
@@ -30,7 +30,8 @@ json_encode = LazyEncoder().encode
 
 class QuillWidget(forms.Textarea):
     class Media:
-        js = MEDIA_JS
+        # Do not include JS files here due to multiple definitions.
+        # js = MEDIA_JS
         css = {"all": MEDIA_CSS}
 
     def __init__(self, config_name="default", *args, **kwargs):


### PR DESCRIPTION
Adding only "field_name" to queryset. It is a safer way, because if you have call_command('convert_to_quill', ...) in db migration, and db schema will be changed in the future, you get error during migration, because db cannot find new field in 'convert_to_quill' command. It exits only in model that time.