### PR TITLE
Load Quill only after DOMContentLoaded

### DIFF
--- a/django_quill/templates/django_quill/widget.html
+++ b/django_quill/templates/django_quill/widget.html
@@ -3,7 +3,7 @@
     <div id="quill-{{ id }}" class="django-quill-widget" data-config="{{ config }}" data-type="django-quill"></div>
     <input id="quill-input-{{ id }}" name="{{ name }}" type="hidden">
     <script>
-        (function () {
+        document.addEventListener("DOMContentLoaded", function() {
             var wrapper = new QuillWrapper('quill-{{ id }}', 'quill-input-{{ id }}', JSON.parse('{{ config|safe|escapejs }}'));
             {% if quill and quill.delta %}
                 // try django_quill/quill.py/Quill instance
@@ -24,6 +24,6 @@
             {% endif %}
             // Allow quill object interaction outer scope
             djq['{{ id }}'] = wrapper;
-        })();
+        });
     </script>
 </div>


### PR DESCRIPTION
Hello !
First, thank’s for this Django Extension ;)

I'm working on a Django project which needs to separate `form.media.css` (in `head`) and `form.media.js` (just before `/body`), but it cause your plugin to fail with a "QuillWrapper not defined" error.

This can be easily corrected by calling the widget script only when DOMContent is fully loaded, which is done by this PR ;) 